### PR TITLE
Updated hisat2 to 2.2.1

### DIFF
--- a/packages/dftbplus/package.py
+++ b/packages/dftbplus/package.py
@@ -1,0 +1,101 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack import *
+
+
+class Dftbplus(CMakePackage):
+    """DFTB+ is an implementation of the
+    Density Functional based Tight Binding (DFTB) method,
+    containing many extensions to the original method."""
+
+    homepage = "https://www.dftbplus.org"
+    url      = "https://github.com/dftbplus/dftbplus/archive/22.1.tar.gz"
+
+    version('22.2', sha256='ca69a5e21bf9071179c5a2c57d89cdcbb0543e771661ac5e8be584fafa4c61df')
+    version('22.1', sha256='f0fc9a076aa2d7be03c31a3a845d8151fc0cc0b1d421e11c37044f78a42abb33')
+    # Disabling the old version so we can use CMakePackage
+    #version('19.1', sha256='4d07f5c6102f06999d8cfdb1d17f5b59f9f2b804697f14b3bc562e3ea094b8a8')
+
+    resource(name='slakos',
+             url='https://github.com/dftbplus/testparams/archive/dftbplus-18.2.tar.gz',
+             sha256='bd191b3d240c1a81a8754a365e53a78b581fc92eb074dd5beb8b56a669a8d3d1',
+             destination='external/slakos',
+             when='@18.2:')
+
+    variant('mpi', default=True,
+            description="Build an MPI-parallelised version of the code.")
+
+    variant('openmp', default=False,
+            description="Build an OpenMP-parallelised version of the code.")
+
+    variant('gpu', default=False,
+            description="Use the MAGMA library "
+            "for GPU accelerated computation")
+
+    variant('elsi', default=False,
+            description="Use the ELSI library for large scale systems. "
+            "Only has any effect if you build with '+mpi'")
+
+    variant('sockets', default=False,
+            description="Whether the socket library "
+            "(external control) should be linked")
+
+    variant('arpack', default=False,
+            description="Use ARPACK for excited state DFTB functionality")
+
+    variant('transport', default=False,
+            description="Whether transport via libNEGF should be included. "
+            "Only affects parallel build. "
+            "(serial version is built without libNEGF/transport)")
+
+    # Disabling it for now (see next comment)
+    # variant('dftd3', default=False,
+    #         description="Use DftD3 dispersion library "
+    #         "(if you need this dispersion model)")
+
+    depends_on('lapack')
+    depends_on('blas')
+    depends_on('scalapack', when="+mpi")
+    depends_on('mpi', when="+mpi")
+    depends_on('elsi', when="+elsi")
+    depends_on('magma', when="+gpu")
+    depends_on('arpack-ng', when="+arpack")
+    # simple-dftd3 was added on spack 0.19
+    # depends_on('simple-dftd3', when="+dftd3")
+
+    def cmake_args(self):
+
+        options = []
+
+        if '+mpi' in self.spec:
+            options.append('-DWITH_MPI=ON')
+            options.append('-DSCALAPACK_LIBRARY={0}'.format(self.spec['scalapack'].libs.joined(';')))
+
+            if '+elsi' in self.spec:
+                options.append('-DWITH_ELSI=ON')
+
+        if '+openmp' in self.spec:
+            options.append('-DWITH_OMP=ON')
+
+        if '+gpu' in self.spec:
+            options.append('-DWITH_GPU=ON')
+
+        if '+sockets' in self.spec:
+            options.append('-DWITH_SOCKETS=ON')
+
+        if '+transport' in self.spec:
+            options.append('-DWITH_TRANSPORT=ON')
+
+        if '+arpack' in self.spec:
+            options.append('-DWITH_ARPACK=ON')
+
+        # if '+dftd3' in self.spec:
+        #     options.append('-DWITH_SDFTD3=ON')
+
+        return options
+

--- a/packages/hisat2/package.py
+++ b/packages/hisat2/package.py
@@ -1,0 +1,112 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import glob
+
+from spack.package import *
+
+
+class Hisat2(MakefilePackage):
+    """HISAT2 is a fast and sensitive alignment program for mapping
+    next-generation sequencing reads (whole-genome, transcriptome, and
+    exome sequencing data) against the general human population (as well as
+    against a single reference genome)."""
+
+    homepage = "https://daehwankimlab.github.io/hisat2/"
+    url = "ftp://ftp.ccb.jhu.edu/pub/infphilo/hisat2/downloads/hisat2-2.1.0-source.zip"
+
+    version(
+        "2.2.1",
+        sha256="48e933330d4d8470d2b3dfe7ec3918f2e98a75f7381891e23b7df1fb4f135eb1",
+        url="https://cloud.biohpc.swmed.edu/index.php/s/fE9QCsX3NH4QwBi/download",
+        extension="zip",
+    )
+    version(
+        "2.2.0",
+        sha256="0dd55168853b82c1b085f79ed793dd029db163773f52272d7eb51b3b5e4a4cdd",
+        url="https://cloud.biohpc.swmed.edu/index.php/s/hisat2-220-source/download",
+        extension="zip",
+    )
+    version("2.1.0", sha256="89a276eed1fc07414b1601947bc9466bdeb50e8f148ad42074186fe39a1ee781")
+
+    # variant("sra", default=False, description="Add SRA (Sequence Read Archive) support")
+
+    depends_on("perl", type="run")
+    depends_on("python", type="run")
+    depends_on("python@:2", when="@:2.2.0")
+    depends_on("python@3:", when="@2.2.1:")
+
+    # depends_on("sra-tools", when="+sra")
+    # depends_on("ncbi-vdb", when="+sra")
+
+    # patch to get SRA working
+    # patch("sra.patch", when="+sra")
+
+    # @when("+sra")
+    # def build(self, spec, prefix):
+    #     make(
+    #         "USE_SRA=1",
+    #         "NCBI_NGS_DIR={0}".format(spec["sra-tools"].prefix),
+    #         "NCBI_VDB_DIR={0}".format(spec["ncbi-vdb"].prefix),
+    #     )
+
+    def install(self, spec, prefix):
+        if spec.satisfies("@:2.1.0"):
+            install_tree("doc", prefix.doc)
+
+        install_tree("example", prefix.example)
+        install_tree("scripts", prefix.scripts)
+
+        if "@:2.2.0" in spec:
+            install_tree("hisatgenotype_modules", prefix.hisatgenotype_modules)
+            install_tree("hisatgenotype_scripts", prefix.hisatgenotype_scripts)
+
+        mkdirp(prefix.bin)
+        install("hisat2", prefix.bin)
+        install("hisat2-align-s", prefix.bin)
+        install("hisat2-align-l", prefix.bin)
+        install("hisat2-build", prefix.bin)
+        install("hisat2-build-s", prefix.bin)
+        install("hisat2-build-l", prefix.bin)
+        install("hisat2-inspect", prefix.bin)
+        install("hisat2-inspect-s", prefix.bin)
+        install("hisat2-inspect-l", prefix.bin)
+        install("*.py", prefix.bin)
+
+        if "@2.2:" in spec:
+            install("hisat2-repeat", prefix.bin)
+
+    @run_after("install")
+    def filter_sbang(self):
+        with working_dir(self.prefix.bin):
+            pattern = "^#!.*/usr/bin/env python"
+            repl = "#!{0}".format(self.spec["python"].command.path)
+            files = [
+                "hisat2-build",
+                "hisat2-inspect",
+            ]
+            for file in files:
+                filter_file(pattern, repl, *files, backup=False)
+
+            pattern = "^#!.*/usr/bin/env perl"
+            repl = "#!{0}".format(self.spec["perl"].command.path)
+            files = [
+                "hisat2",
+            ]
+            for file in files:
+                filter_file(pattern, repl, *files, backup=False)
+
+            pattern = "^#!.*/usr/bin/env python3"
+            repl = "#!{0}".format(self.spec["python"].command.path)
+            files = glob.glob("*.py")
+            for file in files:
+                filter_file(pattern, repl, *files, backup=False)
+
+        with working_dir(self.prefix.scripts):
+            pattern = "^#!.*/usr/bin/perl"
+            repl = "#!{0}".format(self.spec["perl"].command.path)
+            files = glob.glob("*.pl")
+            for file in files:
+                filter_file(pattern, repl, *files, backup=False)


### PR DESCRIPTION
hisat2 2.2.0 depends on python2
other tools needed by the user depend on python3
Commented out a section since it implies some dependencies added in spack 0.19 and we don't need them.

(once this is approved, we need to update the currently installed stack, but we can discuss this elsewhere